### PR TITLE
No longer referencing a non-existent variable

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -13,7 +13,7 @@ module.exports = {
       var request = router.build(url, meta, false);
 
       if (! request) {
-        throw new Error('fluxapp:router:init unable to locate route specified', route);
+        throw new Error('fluxapp:router:init unable to locate route specified', url);
       }
 
       if (isEnabled()) {
@@ -31,7 +31,7 @@ module.exports = {
       var request = router.build(id, meta);
 
       if (! request) {
-        throw new Error('fluxapp:router:Go unable to locate route specified', route);
+        throw new Error('fluxapp:router:Go unable to locate route specified', id);
       }
 
       if (isEnabled()) {


### PR DESCRIPTION
Without this fix a 404 error triggers a ReferenceError.
